### PR TITLE
bitcoin-cli reference is confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,6 @@ open a channel:
 ```bash
 # Returns an address <address>
 lightning-cli newaddr
-
-# Returns a transaction id <txid>
-bitcoin-cli sendtoaddress <address> <amount_in_bitcoins>
 ```
 
 `lightningd` will register the funds once the transaction is confirmed.


### PR DESCRIPTION
User will fund from whatever source they have. If they already have bitcoin-cli funded, then they will know how to fund from it?